### PR TITLE
Fix daemon not booting at startup

### DIFF
--- a/init.d/douane
+++ b/init.d/douane
@@ -5,6 +5,7 @@
 #
 # Author: Guillaume Hain zedtux@zedroot.org
 #
+# chkconfig: - 01 99
 # description: douane is the daemon process of the Douane firewall application. \
 # This firewall is limiting access to the internet on application bases.
 


### PR DESCRIPTION
- Fix douane.service not starting at boot 
- Set the daemon to start before network 
- Set the daemon to stop at latest time possible on shutdown 

init.d, chkconfig and bounding with systemd need those 2 values on legacy service to consider them as service otherwise the daemon is not automatically handled with chkconfig nor systemd (start stop service is possible but enable/disable not possible resulting in fail at startup)
chkconfig: - 01 99
description: douane is...